### PR TITLE
Fix `day` functionality, Ensure `duration` works for same day + test improvement

### DIFF
--- a/natural/date.py
+++ b/natural/date.py
@@ -1,5 +1,6 @@
 from natural.constant import _, _multi
 import datetime
+import math
 
 
 # Wed, 02 Oct 2002 08:00:00 EST
@@ -116,17 +117,18 @@ def delta(t1, t2, words=True, justnow=datetime.timedelta(seconds=10)):
 
     # The datetime module includes milliseconds with float precision. Floats
     # will give unexpected results here, so we round the value here
-    total = int(diff.total_seconds() + 0.5)
+    total = math.ceil(diff.total_seconds())
+    total_abs = abs(total)
 
-    if abs(total) < TIME_DAY:
-        if diff < justnow and words:
+    if total_abs < TIME_DAY:
+        if abs(diff) < justnow and words:
             return (
                 _(u'just now'),
                 0,
             )
 
-        elif abs(total) < TIME_MINUTE:
-            seconds = abs(total)
+        elif total_abs < TIME_MINUTE:
+            seconds = total_abs
             return (
                 _multi(
                     _(u'%d second'),
@@ -134,14 +136,14 @@ def delta(t1, t2, words=True, justnow=datetime.timedelta(seconds=10)):
                 seconds) % (seconds,),
                 0,
             )
-        elif abs(total) < TIME_MINUTE * 2 and words:
+        elif total_abs < TIME_MINUTE * 2 and words:
             return (
                 _(u'a minute'),
                 0,
             )
 
-        elif abs(total) < TIME_HOUR:
-            minutes, seconds = divmod(abs(total), TIME_MINUTE)
+        elif total_abs < TIME_HOUR:
+            minutes, seconds = divmod(total_abs, TIME_MINUTE)
             if total < 0: seconds *= -1
             return (
                 _multi(
@@ -151,14 +153,14 @@ def delta(t1, t2, words=True, justnow=datetime.timedelta(seconds=10)):
                 seconds,
             )
 
-        elif abs(total) < TIME_HOUR * 2 and words:
+        elif total_abs < TIME_HOUR * 2 and words:
             return (
                 _(u'an hour'),
                 0,
             )
 
         else:
-            hours, seconds = divmod(abs(total), TIME_HOUR)
+            hours, seconds = divmod(total_abs, TIME_HOUR)
             if total < 0: seconds *= -1
 
             return (
@@ -169,14 +171,14 @@ def delta(t1, t2, words=True, justnow=datetime.timedelta(seconds=10)):
                 seconds,
             )
 
-    elif abs(total) < TIME_DAY * 2 and words:
+    elif total_abs < TIME_DAY * 2 and words:
         if total > 0:
             return (_(u'tomorrow'), 0)
         else:
             return (_(u'yesterday'), 0)
 
-    elif abs(total) < TIME_WEEK:
-        days, seconds = divmod(abs(total), TIME_DAY)
+    elif total_abs < TIME_WEEK:
+        days, seconds = divmod(total_abs, TIME_DAY)
         if total < 0: seconds *= -1
         return (
             _multi(
@@ -199,7 +201,7 @@ def delta(t1, t2, words=True, justnow=datetime.timedelta(seconds=10)):
 # month/year span.
 
     else:
-        weeks, seconds = divmod(abs(total), TIME_WEEK)
+        weeks, seconds = divmod(total_abs, TIME_WEEK)
         if total < 0: seconds *= -1
         return (
             _multi(

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -34,7 +34,7 @@ class TestDate(object):
         now = time.time()
         for test, expect in (
             (now + 1,       u'just now'),
-            (now + 11,      u'10 seconds from now'),
+            (now + 11,      u'11 seconds from now'),
             (now - 1,       u'just now'),
             (now - 11,      u'11 seconds ago'),
             (now - 3601,    u'an hour ago'),
@@ -47,7 +47,23 @@ class TestDate(object):
             assert result == expect, '%r <> %r' % (result, expect)
 
         for test, expect in (
-            (now + 11,      u'10 seconds from now'),
+            (now + 1,       u'just now'),
+            (now - 1,       u'just now'),
+            (now + 9,       u'just now'),
+            (now - 9,       u'just now'),
+            (now + 60,      u'a minute from now'),
+            (now - 60,      u'a minute ago'),
+            (now + 3600,    u'an hour from now'),
+            (now - 3600,    u'an hour ago'),
+            (now + 7200,    u'2 hours from now'),
+            (now - 7200,    u'2 hours ago'),
+        ):
+
+            result = date.duration(test, precision=1)
+            assert result == expect, '%r <> %r' % (result, expect)
+
+        for test, expect in (
+            (now + 11,      u'11 seconds from now'),
             (now - 1,       u'1 second ago'),
             (now - 11,      u'11 seconds ago'),
             (now - 3601,    u'1 hour, 1 second ago'),
@@ -58,3 +74,22 @@ class TestDate(object):
 
             result = date.duration(test, precision=3)
             assert result == expect, '%r <> %r' % (result, expect)
+
+        for test, justnow, expect in (
+            (now + 1,   datetime.timedelta(seconds=5),  u'just now'),
+            (now - 1,   datetime.timedelta(seconds=5),  u'just now'),
+            (now + 6,   datetime.timedelta(seconds=5),  u'6 seconds from now'),
+            (now - 6,   datetime.timedelta(seconds=5),  u'6 seconds ago'),
+            (now + 59,  datetime.timedelta(seconds=60), u'just now'),
+            (now - 59,  datetime.timedelta(seconds=60), u'just now'),
+            (now + 61,  datetime.timedelta(seconds=60), u'a minute from now'),
+            (now - 61,  datetime.timedelta(seconds=60), u'a minute ago'),
+            (now + 299, datetime.timedelta(minutes=5),  u'just now'),
+            (now - 299, datetime.timedelta(minutes=5),  u'just now'),
+            (now + 301, datetime.timedelta(minutes=5),  u'5 minutes from now'),
+            (now - 301, datetime.timedelta(minutes=5),  u'5 minutes ago'),
+            ):
+
+            result = date.duration(test, justnow=justnow)
+            assert result == expect, '%r <> %r' % (result, expect)
+


### PR DESCRIPTION
This fixes the `day` function to work correctly for day terms in the past (eg yesterday, last week) by considering the absolute difference. The 2nd commit ensures the `duration` function works for datetime objects that happened on the same day by checking the absolute of the time difference.

This also ensures the `total` (total seconds) in the `duration` function is rounded up correctly, resulting in tests which all now pass consistently.  Previously, results were affected by the milliseconds portion of the current time.
