### PR TITLE
Ensure yesterday and tomorrow are determined by absolute date comparison

### DIFF
--- a/natural/date.py
+++ b/natural/date.py
@@ -151,6 +151,7 @@ _to_datetime('2013-12-11T12:34:56'))
     t1 = _to_datetime(t1)
     t2 = _to_datetime(t2)
     diff = t1 - t2
+    date_diff = t1.date() - t2.date()
 
     # The datetime module includes milliseconds with float precision. Floats
     # will give unexpected results here, so we round the value here
@@ -213,11 +214,11 @@ _to_datetime('2013-12-11T12:34:56'))
                 seconds,
             )
 
-    elif total_abs < TIME_DAY * 2 and words:
-        if total > 0:
-            return (_(u'tomorrow'), 0)
-        else:
-            return (_(u'yesterday'), 0)
+    elif date_diff.days == 1 and words:
+        return (_(u'tomorrow'), 0)
+
+    elif date_diff.days == -1 and words:
+        return (_(u'yesterday'), 0)
 
     elif total_abs < TIME_WEEK:
         days, seconds = divmod(total_abs, TIME_DAY)
@@ -325,6 +326,7 @@ def duration(t, now=None, precision=1, pad=u', ', words=None,
                     meaning 'just now'
 
     >>> import time
+    >>> from datetime import datetime
     >>> duration(time.time() + 1)
     u'just now'
     >>> duration(time.time() + 11)
@@ -337,15 +339,20 @@ def duration(t, now=None, precision=1, pad=u', ', words=None,
     u'an hour ago'
     >>> duration(time.time() - 7201)
     u'2 hours ago'
-    >>> duration(time.time() - 123456)
-    u'yesterday'
     >>> duration(time.time() - 1234567)
     u'2 weeks ago'
     >>> duration(time.time() + 7200, precision=1)
     u'2 hours from now'
     >>> duration(time.time() - 1234567, precision=3)
     u'2 weeks, 6 hours, 56 minutes ago'
-
+    >>> duration(datetime(2014, 9, 8), now=datetime(2014, 9, 9))
+    u'yesterday'
+    >>> duration(datetime(2014, 9, 7, 23), now=datetime(2014, 9, 9))
+    u'1 day ago'
+    >>> duration(datetime(2014, 9, 10), now=datetime(2014, 9, 9))
+    u'tomorrow'
+    >>> duration(datetime(2014, 9, 11, 1), now=datetime(2014, 9, 9, 23))
+    u'1 day from now'
     '''
 
     if words is None:


### PR DESCRIPTION
When the delta between two datetime objects is calculated, the notion of yesterday and tomorrow were applied incorrectly.  Specifically, 'tomorrow' and 'yesterday' are calculated on the number of seconds between the datetime objects, rather than on the difference in dates themselves.  This is best illustrated with an example:

``` python
>>> from natural.date import duration
>>> from datetime import datetime
>>> duration(t=datetime(2014,9,7,11), now=datetime(2014,9,9,10)) 
u'yesterday'  # term should only apply to 2014-08-08
>>> duration(t=datetime(2014,9,7,11), now=datetime(2014,9,5,12)) 
u'tomorrow'  # term should only apply to 2014-08-06
>>> duration(t=datetime(2014,9,7,10), now=datetime(2014,9,9,10)) 
u'2 days ago' # okay as >= 2 days ago
```

So in the first instance, because the datetimes are 1 day 23 hours apart (< 2 days worth of seconds), the result is `'yesterday'`, and the second example shows the same for `'tomorrow'`.
[This line](https://github.com/tehmaze/natural/blob/master/natural/date.py#L216) of date.py is the cause in this instance, as it considers the number of seconds rather than the difference in dates.

I think the (only?) way to solve this issue is to take the difference between just the date components of the two datetime objects, and check their difference.  This is what I've done in the given pull request.  Otherwise, there's no way to know when/if a given difference of seconds crosses a given date boundary.
