### PR TITLE
Fix inverted file size units

### DIFF
--- a/natural/constant.py
+++ b/natural/constant.py
@@ -260,7 +260,7 @@ LARGE_NUMBER_SUFFIX = (
 # natural.file
 FILESIZE_SUFFIX = dict(
     decimal=('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'),
-    binary=('iB', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'),
+    binary=('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'),
     gnu='BKMGTPEZY',
 )
 

--- a/natural/data.py
+++ b/natural/data.py
@@ -117,7 +117,7 @@ def sparkline(data):
     ])
 
 
-def throughput(sample, window=1, format='decimal'):
+def throughput(sample, window=1, format='binary'):
     '''
     Return the throughput in (intelli)bytes per second.
 
@@ -127,7 +127,7 @@ def throughput(sample, window=1, format='decimal'):
     :param format: default 'decimal', see :func:`natural.size.filesize`
 
     >>> print(throughput(123456, 42))
-    2.87 kB/s
+    2.87 KiB/s
     '''
 
     if isinstance(window, datetime.timedelta):

--- a/natural/size.py
+++ b/natural/size.py
@@ -3,13 +3,13 @@ from natural.constant import FILESIZE_SUFFIX
 from natural.number import _format
 
 FILESIZE_BASE = dict(
-    decimal=1024,
-    binary=1000,
+    decimal=1000,
+    binary=1024,
     gnu=1024,
 )
 
 
-def filesize(value, format='decimal', digits=2):
+def filesize(value, format='binary', digits=2):
     '''
     Convert a file size into natural readable format. Multiple formats are
     supported.
@@ -22,9 +22,9 @@ def filesize(value, format='decimal', digits=2):
     >>> print(filesize(123))
     123.00 B
     >>> print(filesize(123456))
-    120.56 kB
+    120.56 KiB
     >>> print(filesize(1234567890))
-    1.15 GB
+    1.15 GiB
     '''
 
     if format not in FILESIZE_SUFFIX:
@@ -58,9 +58,9 @@ def decimalsize(value):
     >>> print(decimalsize(123))
     123.00 B
     >>> print(decimalsize(123456))
-    120.56 kB
+    123.46 kB
     >>> print(decimalsize(1234567890))
-    1.15 GB
+    1.23 GB
     '''
     return filesize(value, format='decimal')
 
@@ -70,11 +70,11 @@ def binarysize(value):
     Wrapper for :py:func:`filesize`.
 
     >>> print(binarysize(123))
-    123.00 iB
+    123.00 B
     >>> print(binarysize(123456))
-    123.46 KiB
+    120.56 KiB
     >>> print(binarysize(1234567890))
-    1.23 GiB
+    1.15 GiB
     '''
     return filesize(value, format='binary')
 


### PR DESCRIPTION
The file size units are mixed up. 

Actually the units with 'i' (KiB, MiB, etc.) are the base 2 (binary) units (divisible by 1024), while the units without 'i' (kB, MB), are the base 10 (decimal) SI units.

Plus the 'i' is part of the magnitude prefix, not part of the unit. So it's just Byte (B) not Ibibyte (iB). 

This PR fixes the units and preserves numeric part of the output of filesize, while fixing the suffix.

For more information please see https://en.wikipedia.org/wiki/Orders_of_magnitude_(data)